### PR TITLE
Add period to Knowledge Center Section Text.

### DIFF
--- a/app/pages/knowledge-center.vue
+++ b/app/pages/knowledge-center.vue
@@ -28,7 +28,7 @@ export default {
   },
 
   data: () => ({
-    sectionText: '<p>Put the power of the latest research, seed information and breaking news to work, helping you make more informed management decisions</p>',
+    sectionText: '<p>Put the power of the latest research, seed information and breaking news to work, helping you make more informed management decisions.</p>',
   }),
 
   head() {


### PR DESCRIPTION
I didn’t realze the section teaser and the “Below image text” were distinct entities.
<img width="1920" alt="Screen Shot 2022-03-10 at 9 15 50 AM" src="https://user-images.githubusercontent.com/46794001/157692547-e9872eef-0176-43db-bc5a-eb82d3e9282c.png">
